### PR TITLE
Dev

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,9 +5,6 @@ on:
     branches: [ dev ]
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -17,15 +14,15 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up UV and Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache UV dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,6 +5,9 @@ on:
     branches: [ dev ]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,15 +22,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up UV and Python
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
 
       - name: Cache UV dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-docs-${{ runner.os }}-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up UV and Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v7
@@ -62,8 +64,6 @@ jobs:
       - name: Verify version was bumped
         if: github.event_name == 'pull_request'
         run: |
-          git fetch origin main --depth=1
-
           # Skip version check if only docs/examples changed
           changed=$(git diff --name-only origin/main...HEAD)
           code_changed=$(echo "$changed" | grep -vE '^(docs/|examples/|README\.md|mkdocs\.yml|scripts/|\.github/)' || true)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -20,15 +17,15 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up UV and Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache UV dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [0.4.4] - 2026-03-11
+
+### Added
+- Consumer ProGuard rules for Android — base OneSignal SDK rules (`-dontwarn` for Jackson/AutoValue) are now applied automatically via `consumer-rules.pro`, eliminating R8 errors when using `flet build apk` without `fos-build`
+- Android plugin stub (`FletOneSignalPlugin.java`) — no-op FlutterPlugin that enables Gradle to include the consumer ProGuard rules
+- Separate ProGuard rules for Location module (`-keep` for GoogleApiClient) — injected only when location is enabled
+- Tests for ProGuard rule separation: base rules without location, location-specific rules, no-duplicate with location, empty config without proguard
+
+### Changed
+- `_inject_proguard_rules()` now accepts `location` parameter to control location-specific rule injection
+- `_build_android()` always injects base ProGuard rules regardless of optional module configuration
+- `_check_onesignal_modules()` validates both base and location-specific ProGuard markers
+- Flet compatibility: updated `pubspec.yaml` to declare Android plugin platform with `pluginClass: FletOneSignalPlugin`
+
+### Fixed
+- R8 build error (`Missing classes: JsonFactory, JsonGenerator, AutoValue$CopyAnnotations`) when building release APK — caused by OneSignal SDK's transitive OpenTelemetry dependency referencing classes not present at runtime
+
 ## [0.4.3] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ ONESIGNAL_APP_ID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 async def main(page: ft.Page):
     page.title = "My App"
+    page.vertical_alignment = ft.CrossAxisAlignment.CENTER
+    page.horizontal_alignment = ft.MainAxisAlignment.CENTER
 
     # Initialize OneSignal
     onesignal = fos.OneSignal(

--- a/README.md
+++ b/README.md
@@ -897,20 +897,26 @@ Automated test app that exercises every SDK method with a single tap and display
 
 ---
 
-## 🌐 Community
+## Learn more
+* [Documentation](https://brunobrown.github.io/flet-onesignal)
+
+## Flet Community
 
 Join the community to contribute or get help:
 
-- [Discord](https://discord.gg/dzWXP8SHG8)
-- [GitHub Issues](https://github.com/brunobrown/flet-asp/issues)
+* [Discussions](https://github.com/flet-dev/flet/discussions)
+* [Discord](https://discord.gg/dzWXP8SHG8)
+* [X (Twitter)](https://twitter.com/fletdev)
+* [Bluesky](https://bsky.app/profile/fletdev.bsky.social)
+* [Email us](mailto:hello@flet.dev)
 
-## ⭐ Support
+## Support
 
-If you like this project, please give it a [GitHub star](https://github.com/brunobrown/flet-asp) ⭐
+If you like this project, please give it a [GitHub star](https://github.com/brunobrown/flet-onesignal) ⭐
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
 Contributions and feedback are welcome!
 
@@ -918,14 +924,11 @@ Contributions and feedback are welcome!
 2. Create a feature branch
 3. Submit a pull request with detailed explanation
 
-For feedback, [open an issue](https://github.com/brunobrown/flet-asp/issues) with your suggestions.
+For feedback, [open an issue](https://github.com/brunobrown/flet-onesignal/issues) with your suggestions.
 
 ---
+## Try flet-onesignal today and enhance your Flet apps with push notifications!
 
-## Try **flet-onesignal** today and enhance your Flet apps with push notifications!
-
----
 
 <p align="center"><img src="https://github.com/user-attachments/assets/431aa05f-5fbc-4daa-9689-b9723583e25a" width="50%"></p>
 <p align="center"><a href="https://www.bible.com/bible/116/PRO.16.NLT"> Commit your work to the LORD, and your plans will succeed. Proverbs 16:3</a></p>
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flet-onesignal"
-version = "0.4.3"
+version = "0.4.4"
 description = "Flutter OneSignal package integration for Python Flet."
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/flet_onesignal/__init__.py
+++ b/src/flet_onesignal/__init__.py
@@ -97,4 +97,4 @@ __all__ = [
     "Language",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.4.4"

--- a/src/flet_onesignal/build.py
+++ b/src/flet_onesignal/build.py
@@ -183,37 +183,56 @@ def _inject_onesignal_modules(flutter_dir: Path, config: dict) -> bool:
         if modified:
             app_gradle.write_text(content)
 
-    # Inject ProGuard rules to prevent R8 from stripping reflection targets
-    if modified and config.get("location"):
-        _inject_proguard_rules(app_dir)
+    # Inject ProGuard rules to suppress R8 warnings
+    if modified:
+        _inject_proguard_rules(app_dir, location=bool(config.get("location")))
 
     return modified
 
 
 _ONESIGNAL_PROGUARD_RULES = """\
+# OneSignal SDK — suppress R8 warnings for transitive dependencies
+-dontwarn com.fasterxml.jackson.core.JsonFactory
+-dontwarn com.fasterxml.jackson.core.JsonGenerator
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations
+"""
+
+_ONESIGNAL_LOCATION_PROGUARD_RULES = """\
 # OneSignal Location module uses reflection on GoogleApiClient internals
 -keep class com.google.android.gms.common.api.GoogleApiClient { *; }
 -keep class com.google.android.gms.common.api.internal.zab* { *; }
 """
 
-_PROGUARD_MARKER = "# OneSignal Location module"
+_PROGUARD_MARKER = "# OneSignal SDK"
+_PROGUARD_LOCATION_MARKER = "# OneSignal Location module"
 
 
-def _inject_proguard_rules(app_dir: Path) -> None:
-    """Add ProGuard keep rules for OneSignal Location reflection targets."""
+def _inject_proguard_rules(app_dir: Path, *, location: bool = False) -> None:
+    """Add ProGuard rules for OneSignal SDK and optional Location module."""
     proguard_file = app_dir / "proguard-rules.pro"
 
-    # Write the rules file
     if proguard_file.exists():
         content = proguard_file.read_text()
-        if _PROGUARD_MARKER in content:
-            return
-        content += "\n" + _ONESIGNAL_PROGUARD_RULES
-        proguard_file.write_text(content)
     else:
-        proguard_file.write_text(_ONESIGNAL_PROGUARD_RULES)
+        content = ""
 
-    ui.modified("Injected: ProGuard rules for OneSignal Location")
+    changed = False
+
+    # Always inject base SDK rules (Jackson/AutoValue dontwarn)
+    if _PROGUARD_MARKER not in content:
+        content += "\n" + _ONESIGNAL_PROGUARD_RULES
+        changed = True
+
+    # Inject Location module keep rules only when location is enabled
+    if location and _PROGUARD_LOCATION_MARKER not in content:
+        content += "\n" + _ONESIGNAL_LOCATION_PROGUARD_RULES
+        changed = True
+
+    if not changed:
+        return
+
+    proguard_file.write_text(content.lstrip("\n"))
+    ui.modified("Injected: ProGuard rules for OneSignal SDK")
 
     # Ensure the build.gradle(.kts) references the proguard file in the release buildType
     app_kts = app_dir / "build.gradle.kts"
@@ -250,11 +269,14 @@ def _check_onesignal_modules(flutter_dir: Path, config: dict) -> bool:
         if maven_coord not in content:
             return False
 
-    # Check ProGuard rules for location
-    if config.get("location"):
-        proguard_file = app_dir / "proguard-rules.pro"
-        if not proguard_file.exists() or _PROGUARD_MARKER not in proguard_file.read_text():
-            return False
+    # Check base ProGuard rules (always required)
+    proguard_file = app_dir / "proguard-rules.pro"
+    if not proguard_file.exists() or _PROGUARD_MARKER not in proguard_file.read_text():
+        return False
+
+    # Check location-specific ProGuard rules
+    if config.get("location") and _PROGUARD_LOCATION_MARKER not in proguard_file.read_text():
+        return False
 
     return True
 
@@ -339,37 +361,32 @@ def _build_android(
 
     flutter_dir = project_root / "build" / "flutter"
     android_dir = flutter_dir / "android"
+    app_dir = android_dir / "app"
+    has_optional_modules = bool(_collect_onesignal_deps(onesignal_config))
+    location_enabled = bool(onesignal_config.get("location"))
 
-    # No modules enabled → single pass (same as non-android)
-    if not _collect_onesignal_deps(onesignal_config):
-        ui.build_info(f"Building {args.build_type.upper()}...")
-
-        result = subprocess.run(cmd, cwd=project_root)
-
-        if result.returncode == 0:
-            _handle_success(args.build_type, project_root)
-        else:
-            ui.failure_panel(FAILURE_TIPS)
-
-        sys.exit(result.returncode)
-
-    # Modules enabled and gradle already configured → single pass
+    # Check if everything is already configured (ProGuard + optional modules)
     if android_dir.exists() and _check_onesignal_modules(flutter_dir, onesignal_config):
-        ui.build_info(
-            f"Building {args.build_type.upper()} (OneSignal modules already configured)..."
-        )
+        # Also check that base ProGuard rules are present
+        proguard_file = app_dir / "proguard-rules.pro"
+        proguard_ok = proguard_file.exists() and _PROGUARD_MARKER in proguard_file.read_text()
 
-        result = subprocess.run(cmd, cwd=project_root)
+        if proguard_ok:
+            ui.build_info(f"Building {args.build_type.upper()} (OneSignal already configured)...")
+            result = subprocess.run(cmd, cwd=project_root)
 
-        if result.returncode == 0:
-            _handle_success(args.build_type, project_root)
-        else:
-            ui.failure_panel(FAILURE_TIPS)
+            if result.returncode == 0:
+                _handle_success(args.build_type, project_root)
+            else:
+                ui.failure_panel(FAILURE_TIPS)
 
-        sys.exit(result.returncode)
+            sys.exit(result.returncode)
 
-    # Modules enabled but gradle not configured → first pass + inject + rebuild
-    ui.build_info(f"Building {args.build_type.upper()} with OneSignal modules...")
+    # First pass: create Flutter project so we can inject into gradle files
+    if has_optional_modules:
+        ui.build_info(f"Building {args.build_type.upper()} with OneSignal modules...")
+    else:
+        ui.build_info(f"Building {args.build_type.upper()}...")
     ui.step(1, "Creating Flutter project...")
 
     result = subprocess.run(cmd, cwd=project_root)
@@ -381,10 +398,15 @@ def _build_android(
         )
         sys.exit(1)
 
-    ui.step(2, "Injecting OneSignal module dependencies...")
-    _inject_onesignal_modules(flutter_dir, onesignal_config)
+    # Inject optional module dependencies (location, etc.)
+    if has_optional_modules:
+        ui.step(2, "Injecting OneSignal module dependencies...")
+        _inject_onesignal_modules(flutter_dir, onesignal_config)
 
-    ui.step(3, "Rebuilding with OneSignal modules...")
+    # Always inject base ProGuard rules for OneSignal SDK
+    _inject_proguard_rules(app_dir, location=location_enabled)
+
+    ui.step(3 if has_optional_modules else 2, "Rebuilding with OneSignal configuration...")
 
     result = subprocess.run(cmd, cwd=project_root)
 

--- a/src/flutter/flet_onesignal/android/build.gradle
+++ b/src/flutter/flet_onesignal/android/build.gradle
@@ -1,0 +1,40 @@
+group 'com.flet.onesignal'
+version '1.0'
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.0.0'
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.flet.onesignal'
+    }
+
+    compileSdkVersion 34
+
+    defaultConfig {
+        minSdkVersion 21
+        consumerProguardFiles 'consumer-rules.pro'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+}

--- a/src/flutter/flet_onesignal/android/consumer-rules.pro
+++ b/src/flutter/flet_onesignal/android/consumer-rules.pro
@@ -1,0 +1,5 @@
+# OneSignal SDK — suppress R8 warnings for transitive dependencies
+# (OpenTelemetry pulls Jackson and AutoValue which are not used at runtime)
+-dontwarn com.fasterxml.jackson.core.JsonFactory
+-dontwarn com.fasterxml.jackson.core.JsonGenerator
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations

--- a/src/flutter/flet_onesignal/android/src/main/AndroidManifest.xml
+++ b/src/flutter/flet_onesignal/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.flet.onesignal">
+</manifest>

--- a/src/flutter/flet_onesignal/android/src/main/java/com/flet/onesignal/FletOneSignalPlugin.java
+++ b/src/flutter/flet_onesignal/android/src/main/java/com/flet/onesignal/FletOneSignalPlugin.java
@@ -1,0 +1,24 @@
+package com.flet.onesignal;
+
+import androidx.annotation.NonNull;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+
+/**
+ * No-op Android plugin stub for flet_onesignal.
+ *
+ * This class exists solely so Flutter recognizes the android/ directory
+ * and applies the consumer ProGuard rules defined in consumer-rules.pro.
+ * All actual OneSignal functionality is handled via the Dart-side
+ * FletExtension (onesignal_service.dart).
+ */
+public class FletOneSignalPlugin implements FlutterPlugin {
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+        // no-op — real logic lives in the Dart FletExtension
+    }
+
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        // no-op
+    }
+}

--- a/src/flutter/flet_onesignal/pubspec.yaml
+++ b/src/flutter/flet_onesignal/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flet_onesignal
 description: "Flutter OneSignal package integration for Python Flet."
-version: 0.4.0
+version: 0.4.4
 repository: https://github.com/brunobrown/flet-onesignal
 
 environment:
@@ -21,3 +21,8 @@ dev_dependencies:
   flutter_lints: ^5.0.0
 
 flutter:
+  plugin:
+    platforms:
+      android:
+        package: com.flet.onesignal
+        pluginClass: FletOneSignalPlugin

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -3,6 +3,7 @@
 import textwrap
 
 from flet_onesignal.build import (
+    _PROGUARD_LOCATION_MARKER,
     _PROGUARD_MARKER,
     _check_onesignal_modules,
     _collect_onesignal_deps,
@@ -159,6 +160,23 @@ class TestInjectProguardRules:
         assert proguard.exists()
         assert _PROGUARD_MARKER in proguard.read_text()
 
+    def test_base_rules_without_location(self, tmp_path):
+        app_dir = tmp_path / "app"
+        app_dir.mkdir()
+        _inject_proguard_rules(app_dir)
+        content = (app_dir / "proguard-rules.pro").read_text()
+        assert "dontwarn com.fasterxml.jackson" in content
+        assert _PROGUARD_LOCATION_MARKER not in content
+
+    def test_location_rules_included(self, tmp_path):
+        app_dir = tmp_path / "app"
+        app_dir.mkdir()
+        _inject_proguard_rules(app_dir, location=True)
+        content = (app_dir / "proguard-rules.pro").read_text()
+        assert _PROGUARD_MARKER in content
+        assert _PROGUARD_LOCATION_MARKER in content
+        assert "GoogleApiClient" in content
+
     def test_appends_to_existing(self, tmp_path):
         app_dir = tmp_path / "app"
         app_dir.mkdir()
@@ -175,6 +193,15 @@ class TestInjectProguardRules:
         _inject_proguard_rules(app_dir)
         content_first = (app_dir / "proguard-rules.pro").read_text()
         _inject_proguard_rules(app_dir)
+        content_second = (app_dir / "proguard-rules.pro").read_text()
+        assert content_first == content_second
+
+    def test_no_duplicate_with_location(self, tmp_path):
+        app_dir = tmp_path / "app"
+        app_dir.mkdir()
+        _inject_proguard_rules(app_dir, location=True)
+        content_first = (app_dir / "proguard-rules.pro").read_text()
+        _inject_proguard_rules(app_dir, location=True)
         content_second = (app_dir / "proguard-rules.pro").read_text()
         assert content_first == content_second
 
@@ -216,7 +243,7 @@ class TestCheckOnesignalModules:
         """)
         )
         proguard = app_dir / "proguard-rules.pro"
-        proguard.write_text(_PROGUARD_MARKER)
+        proguard.write_text(f"{_PROGUARD_MARKER}\n{_PROGUARD_LOCATION_MARKER}\n")
         assert _check_onesignal_modules(tmp_path, {"location": True}) is True
 
     def test_module_missing(self, tmp_path):
@@ -253,4 +280,14 @@ class TestCheckOnesignalModules:
         app_dir.mkdir(parents=True)
         gradle = app_dir / "build.gradle.kts"
         gradle.write_text("dependencies {\n}\n")
+        proguard = app_dir / "proguard-rules.pro"
+        proguard.write_text(_PROGUARD_MARKER)
         assert _check_onesignal_modules(tmp_path, {}) is True
+
+    def test_empty_config_no_proguard(self, tmp_path):
+        """Without ProGuard rules, even empty config should return False."""
+        app_dir = tmp_path / "android" / "app"
+        app_dir.mkdir(parents=True)
+        gradle = app_dir / "build.gradle.kts"
+        gradle.write_text("dependencies {\n}\n")
+        assert _check_onesignal_modules(tmp_path, {}) is False


### PR DESCRIPTION
## Summary by Sourcery

Add Android consumer ProGuard rules and plugin stub to ensure OneSignal SDK builds cleanly with R8 and integrate them into the existing build pipeline, while updating metadata, docs, and CI tooling.

New Features:
- Provide Android consumer ProGuard rules and a no-op Flutter plugin stub so Flutter/Gradle always apply OneSignal SDK R8 suppression rules, even when building without the custom builder.
- Expose platform plugin configuration for Android in the Flutter pubspec so the flet_onesignal package is recognized as a Flutter plugin.

Bug Fixes:
- Resolve Android R8 release build errors caused by missing Jackson and AutoValue classes from OneSignal's transitive dependencies when building APKs.

Enhancements:
- Refine ProGuard rule injection to always add base OneSignal SDK rules and conditionally add location-specific rules, with corresponding validation in the build checks.
- Improve the Android build flow to inject OneSignal configuration and ProGuard rules in a first-pass build regardless of optional module usage, and reuse configuration when already present.
- Clarify README usage example layout and update community/support links and repository references.
- Update package versioning across the project to 0.4.4 and declare Android plugin metadata for improved Flet compatibility.

Build:
- Add Android library Gradle configuration, consumer ProGuard rules, and manifest for the flet_onesignal Flutter plugin so that the SDK's ProGuard rules are packaged and applied automatically in consuming apps.

CI:
- Refresh GitHub Actions workflows to newer versions of checkout, setup-uv, and cache actions and rely on full-depth fetch from checkout for version checks.

Documentation:
- Document the new release in the changelog, including ProGuard/R8 handling, Android plugin stub, and Flet compatibility details.

Tests:
- Extend build tests to cover separation of base vs. location-specific ProGuard rules, prevention of duplicate injections, and behavior when ProGuard rules are missing even with an empty configuration.